### PR TITLE
added Dockerfile to generate container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+from physino/root
+
+run curl -LO https://github.com/schol/dukecevns/archive/refs/heads/master.zip \
+ && curl -LO https://github.com/nlohmann/json/archive/refs/heads/develop.zip \
+ && unzip master.zip && mv dukecevns-master /root/dukecevns \
+ && unzip develop.zip && mv json-develop/* /root/dukecevns/json \
+ && rm -fr *.zip json-develop
+
+# overwrite the default working directory: /root/
+workdir /root/dukecevns


### PR DESCRIPTION
The `Dockerfile` is used to generate docker images on <https://hub.docker.com/r/physino/dukecevns>. The image contains everything that's needed to compile dukecevns.