### PR TITLE
Removed std flag from CXXFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 ROOTCFLAGS = `root-config --cflags`
 ROOTLIBS   = `root-config --libs`
 
-CXXFLAGS += -I. -I./json/include -Wall -std=c++11 
+CXXFLAGS += -I. -I./json/include -Wall
 
 
 %.o : %.c


### PR DESCRIPTION
std flag is included in root-config --cflags. Hardcoding the std flag leads to errors when it is a different version than specified in root-config --cflags.